### PR TITLE
checking for datastore is being deleted

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -491,6 +492,17 @@ func (e *Exporter) getDatastoreMetric(datastore Datastore, ch chan<- prometheus.
 
 	// check if status code is 200
 	if resp.StatusCode != 200 {
+		if resp.StatusCode == 400 {
+			// check if
+			isBeingDeleted, err := regexp.MatchString("(?i)datastore is being deleted", string(body[:]))
+			if err != nil {
+				return err
+			}
+			if isBeingDeleted {
+				log.Printf("INFO: Datastore: %s is being deleted, Skip scrape datastore metric", datastore.Store)
+				return nil
+			}
+		}
 		return fmt.Errorf("ERROR: --Status code %d returned from endpoint: %s", resp.StatusCode, e.endpoint)
 	}
 

--- a/main.go
+++ b/main.go
@@ -493,7 +493,7 @@ func (e *Exporter) getDatastoreMetric(datastore Datastore, ch chan<- prometheus.
 	// check if status code is 200
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 400 {
-			// check if
+			// check if datastore is being deleted
 			isBeingDeleted, err := regexp.MatchString("(?i)datastore is being deleted", string(body[:]))
 			if err != nil {
 				return err


### PR DESCRIPTION
Exporter will set pbs_up = 0 when some datastore is being deleted
I think It does not make sense to set pbs_up = 0 because the proxmox backup server still working and can get other metrics.