### PR TITLE
allow empty string ("") namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -540,11 +540,6 @@ func (e *Exporter) getDatastoreMetric(datastore Datastore, ch chan<- prometheus.
 
 	// for each namespace collect metrics
 	for _, namespace := range response.Data {
-		// if namespace is empty skip
-		if namespace.Namespace == "" {
-			continue
-		}
-
 		err := e.getNamespaceMetric(datastore.Store, namespace.Namespace, ch)
 		if err != nil {
 			return err


### PR DESCRIPTION
I never set a namespace, so I'm thinking "" is the default. My `/admin/datastore/{store}/namespace` returns `{"data":[{"ns":""}]}`. After removing this skip, I can see `pbs_snapshot_*` stats.

Thanks for putting this project up!