### PR TITLE
feat: Add version metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Metrics are retrieved using the [Proxmox Backup Server API](https://pbs.proxmox.
 | Metric                         | Meaning                                                 | Labels                                       |
 | ------------------------------ | ------------------------------------------------------- | -------------------------------------------- |
 | pbs_up                         | Was the last query of Proxmox Backup Server successful? |                                              |
+| pbs_version                    | Version of Proxmox Backup Server                        | `version`, `repoid`, `release`               |
 | pbs_available                  | The available bytes of the underlying storage.          | `datastore`                                  |
 | pbs_size                       | The size of the underlying storage in bytes.            | `datastore`                                  |
 | pbs_used                       | The used bytes of the underlying storage.               | `datastore`                                  |

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var (
 	version = prometheus.NewDesc(
 		prometheus.BuildFQName(promNamespace, "", "version"),
 		"Version of the PBS installation.",
-		[]string{"version"}, nil,
+		[]string{"version", "repoid", "release"}, nil,
 	)
 	available = prometheus.NewDesc(
 		prometheus.BuildFQName(promNamespace, "", "available"),
@@ -443,7 +443,7 @@ func (e *Exporter) getVersion(ch chan<- prometheus.Metric) error {
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		version, prometheus.GaugeValue, 1, response.Data.Version,
+		version, prometheus.GaugeValue, 1, response.Data.Version, response.Data.Repoid, response.Data.Release,
 	)
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to natrontech/pbs-exporter.
-->

**What this PR does**:  

Add support for version metrics retrieved from PBS API.

**Notes for Reviewer**:

We have to set the version as a label because this is not a "metric". This mimic what is done with the pve_exporter <https://github.com/prometheus-pve/prometheus-pve-exporter>

**Checklist**:

- [x] I have read and understood the [CONTRIBUTING](https://github.com/natrontech/pbs-exporter/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/natrontech/pbs-exporter/blob/main/CODE_OF_CONDUCT.md) documents
- [x] Pull Request title in the format of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) e.g. `feat|fix|chore|docs|...: Changed Something`
- [x] Updated documentation in the  `README.md` file (e.g. new parameters, environment variables, return values, ...) 