### PR TITLE
chore(pbs-exporter): bumped golangci-lint from 1.64 to 2.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,4 +27,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.7
+          version: v2.2.2


### PR DESCRIPTION
Bumps golanci-lint from 1.64 to 2.2